### PR TITLE
Fix python indenting error on line 6405 of CRStools/test.ipynb

### DIFF
--- a/CRStools/utils.py
+++ b/CRStools/utils.py
@@ -9,7 +9,7 @@ import os
 import astropy.units as u
 import astropy.coordinates as coord
 from astropy.coordinates import SkyCoord, frame_transform_graph
-from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
+from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_transpose
 from astropy.table import Table
 import glob
 # to avoid this warning:
@@ -260,7 +260,7 @@ def get_desi_bright_bgs_sel(cat, mag_r_lim=19.5):
    
     
 def projection_ra(ra, ra_center=0):
-    """Shift `ra` to the origin of the Axes object and convert to radians.
+    r"""Shift `ra` to the origin of the Axes object and convert to radians.
 
     Parameters
     ----------
@@ -556,7 +556,7 @@ def SGR_MATRIX():
     C = rotation_matrix(SGR_THETA, "x")
     B = rotation_matrix(SGR_PSI, "z")
     A = np.diag([1., 1., -1.])
-    SGR_matrix = matrix_product(A, B, C, D)
+    SGR_matrix = A @ B @ C @ D
     return SGR_matrix
 
 


### PR DESCRIPTION
In commit 8a822375 of 4MOST_CRS_tools in CRStools/

  jupyter nbconvert test.ipynb --to python

fails because of an indentation error. This is because line 6405 of CRStools/test.ipynb with '@classmethod' has only two spaces instead of four spaces.

This commit inserts two extra spaces to fix the indenting; 'jupyter nbconvert test.ipynb --to python' works for me after the fix. This commit fixes bug #1 [1].

[1] https://github.com/4most-crs/4MOST_CRS_tools/issues/1